### PR TITLE
UserContents AuthUserContents maxWidth削除

### DIFF
--- a/backend/resources/ts/user/components/organisms/AuthUserContents.tsx
+++ b/backend/resources/ts/user/components/organisms/AuthUserContents.tsx
@@ -8,7 +8,6 @@ type Props = {
     userName?: string
     value: string
     handleChange: (event: React.ChangeEvent<{}>, newValue: string) => void
-    handleChangeIndex: (index: string) => void
 }
 
 type TabPanelProps = {
@@ -46,7 +45,6 @@ function a11yProps(index: any) {
 const useStyles = makeStyles((theme) => ({
     root: {
         width: '90%',
-        maxWidth: '33rem',
         marginTop: theme.spacing(3),
         marginLeft: 'auto',
         marginRight: 'auto'

--- a/backend/resources/ts/user/components/organisms/UserContents.tsx
+++ b/backend/resources/ts/user/components/organisms/UserContents.tsx
@@ -44,7 +44,6 @@ function a11yProps(index: any) {
 const useStyles = makeStyles((theme) => ({
     root: {
         width: '90%',
-        maxWidth: '33rem',
         marginTop: theme.spacing(3),
         marginLeft: 'auto',
         marginRight: 'auto'
@@ -76,9 +75,7 @@ const UserContents: React.FC<Props> = ({
     const handleChange = (event: React.ChangeEvent<{}>, newValue: string) => {
         setValue(newValue)
     }
-    // const handleChangeIndex = (index: string) => {
-    //     setValue(index)
-    // }
+
     return (
 
         <Box className={classes.root}>

--- a/backend/resources/ts/user/components/pages/UserFollowCount.tsx
+++ b/backend/resources/ts/user/components/pages/UserFollowCount.tsx
@@ -11,7 +11,6 @@ type Props = {
     value: string
     userName: string
     handleChange: (event: React.ChangeEvent<{}>, newValue: string) => void
-    handleChangeIndex: (index: string) => void
     goToOtherUser: (userName: string) => void
 }
 

--- a/backend/resources/ts/user/containers/organisms/AuthUserContent.tsx
+++ b/backend/resources/ts/user/containers/organisms/AuthUserContent.tsx
@@ -11,15 +11,11 @@ const EnhancedAuthUserContent: React.FC = () => {
         setValue(newValue)
     }
 
-    const handleChangeIndex = (index: string) => {
-        setValue(index)
-    }
     return (
         <AuthUserContents
             userName={currentUser?.name}
             value={value}
             handleChange={handleChange}
-            handleChangeIndex={handleChangeIndex}
         />
     )
 }

--- a/backend/resources/ts/user/containers/pages/UserFollowCount.tsx
+++ b/backend/resources/ts/user/containers/pages/UserFollowCount.tsx
@@ -11,9 +11,6 @@ const EnhancedUserFollowCount: React.FC = () => {
         setValue(newValue)
     }
 
-    const handleChangeIndex = (index: string) => {
-        setValue(index)
-    }
 
     const goToOtherUser = useCallback(
         (userName: string) => {
@@ -26,7 +23,6 @@ const EnhancedUserFollowCount: React.FC = () => {
         <UserFollowCount
             value={value}
             handleChange={handleChange}
-            handleChangeIndex={handleChangeIndex}
             userName={userName}
             goToOtherUser={goToOtherUser}
         />


### PR DESCRIPTION
resolve #8 
![スクリーンショット 2022-03-15 9 11 28](https://user-images.githubusercontent.com/59017603/158281431-0278a683-9c36-4315-a5ee-b4553e01e675.jpg)


コメントアウトされている maxWidthを削除しましたところ表示が崩れなくなりました
UserContents と AuthUserContentsの 両方にてきおうしました